### PR TITLE
WebGL crash exploit

### DIFF
--- a/Exploits/WebGL crash exploit
+++ b/Exploits/WebGL crash exploit
@@ -1,0 +1,7 @@
+(stpv22)
+I found out recently that if you can some how get WebGL to crash, you can access website without goguardian redirecting you.
+
+1: make a bookmark of the website you want to visit.
+2: get WebGL to crash, I don't know how to do this other than being teleported to a large amount of players withing you render
+  distance while in fullscreen in EaglercraftX sometimes.
+3: Rapidly click the bookmark, should be like four times, until goguardian stops redirecting you.


### PR DESCRIPTION
Is there another sure-fire way of getting WebGL to stop working?