### PR TITLE
Correct Lightspeed cache duration in instructions

### DIFF
--- a/Exploits/Break Extensions - OmadaDNS.txt
+++ b/Exploits/Break Extensions - OmadaDNS.txt
@@ -17,7 +17,7 @@ Instructions:
 
 Issues:
 -> GoGuardian is patching this soon with a hardcoded list. Common sites like Discord will stay blocked, but you will still be able to use about any proxy link.
--> Lightspeed keeps a cache for two weeks of blocked websites. Simply use the DNS for more than two weeks. It might also work if you clear the cache for all time in chrome://settings/clearBrowserData, and ensuring cache is selected and time is all time.
+-> Lightspeed keeps a cache for one week of blocked websites. Simply use the DNS for more than one weeks. It might also work if you clear the cache for all time in chrome://settings/clearBrowserData, and ensuring cache is selected and time is all time.
 -> This does NOT work on filters such as ContentKeeper, iboss, most Cisco configurations, or FortiGuard. They are network level.
 -> If you're already using OmadaDNS, continue to do so, and DO NOT connect to a wifi network without it, unless your extensions may update and be patched.
 -> This commonly breaks locked mode quizzes. To fix them, revert the DNS, reboot your Chromebook, go to chrome://policy and press "refresh policies".

--- a/Exploits/Break Extensions - OmadaDNS.txt
+++ b/Exploits/Break Extensions - OmadaDNS.txt
@@ -8,16 +8,16 @@ Notes:
 
 Instructions:
 1. Go to your settings.
-2. Click on the wifi name you are using and click it again.
+2. Click on the Wi-Fi name you are using and click it again.
 3. Go to the 'Network' section and click it.
 4. Scroll down until you find the 'Name servers' section.
 5. Change the option to 'Custom Name Servers'.
 6. Set the first field to 66.23.198.252, the second field to 66.94.105.229, the third field to 167.86.91.171, and the fourth to 0.0.0.0
-7. Refresh your network connection by turning your wifi off and on.
+7. Refresh your network connection by turning your Wi-Fi off and on.
 
 Issues:
 -> GoGuardian is patching this soon with a hardcoded list. Common sites like Discord will stay blocked, but you will still be able to use about any proxy link.
--> Lightspeed keeps a cache for one week of blocked websites. Simply use the DNS for more than one weeks. It might also work if you clear the cache for all time in chrome://settings/clearBrowserData, and ensuring cache is selected and time is all time.
+-> Lightspeed keeps a cache for one week of blocked websites. Simply use the DNS for more than one week. It might also work if you clear the cache for all time in chrome://settings/clearBrowserData, and ensuring cache is selected and time is all time.
 -> This does NOT work on filters such as ContentKeeper, iboss, most Cisco configurations, or FortiGuard. They are network level.
 -> If you're already using OmadaDNS, continue to do so, and DO NOT connect to a wifi network without it, unless your extensions may update and be patched.
 -> This commonly breaks locked mode quizzes. To fix them, revert the DNS, reboot your Chromebook, go to chrome://policy and press "refresh policies".


### PR DESCRIPTION
Updated the caching duration for Lightspeed from two weeks to one week and adjusted related instructions.
I am currently reverse engineering lightspeed code here is where it says 7 days: in function: _0x206003 it shows all of these: 
```
var _0x206003 = {
        blockSettings: {},
        captivePortalActive: true,
        ccInterval: 604800000,
        helperId: 'egnmgclkeiioginamdjpnglaooajmcjm',
        lastPolicyEpochMS: 0,
        liveActivityActive: false,
        noSubDomains: [],
        online: true,
        osDisable: false,
        platform: { os: 'cros' },
        plInterval: 300000,
        publicIp: '127.0.0.1',
        publicKeyProd: (i took this out cause its a api key),
        publicKeyStag: (another api key),
        rpInterval: 15000,
        shortCats: [
          0,
          14,
          31
        ],
        validPolicy: true
      };
```
here it is decoded with my comments:
```
      var defaultarray = { //when nothing in memory use these default block settings (which is no block)
        blockSettings: {}, //nothing fetches i think
        captivePortalActive: true,
        ccInterval: 604800000, //Fetch interval? no clear cache interval? 7 days in ms ohhhhh cc is clearcache
        helperId: 'egnmgclkeiioginamdjpnglaooajmcjm', //extension id
        lastPolicyEpochMS: 0, //last policy fetch
        liveActivityActive: false, //whether live activity/monitoring is active or not
        noSubDomains: [], //will treats these subdomains as root domain
        online: true, //if the browser is online or not
        osDisable: false, //dont know
        platform: { os: 'cros' }, //operating system (chrombook cros=chrome os)
        plInterval: 300000, //this is fetch interval for policy list, 5 minutes in ms
        publicIp: '127.0.0.1', //default public ip? not sure if this is used anywhere but its the default value in memory until we fetch the real one
        publicKeyProd: (im taking them out), //to use default since lets say device has no key this is the default key
        publicKeyStag: (another one), //also no real use
        rpInterval: 15000, //reporting interval? 15 seconds in ms
        shortCats: [ //catogories that are skipped for logging
          0,
          14,
          31
        ],
        validPolicy: true //if its a valid usable policy
      };
```
also is there anyone managing this repo i can work with to deob the rest? is there anyone with deob knowledge?
also is it possible i can have edit access